### PR TITLE
Parlia integration

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -1,6 +1,7 @@
 PAGE_ROOT_URL=http://localhost:2000
 CORAL_ROOT_URL=http://localhost:3000
 SERVICE_ROOT_URL=http://localhost:4000
+PARLIA_EMBED_URL=http://localhost:4000/parlia-embed-local.js
 SITE_PORT=2000
 SERVICE_PORT=4000
 PROTOCOL=http://

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN npm install
 COPY . .
 
 EXPOSE 8080
-CMD [ "node", "server-service.js" ]
+CMD [ "node", "server-fake-site.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,4 @@ RUN npm install
 # Bundle app source
 COPY . .
 
-EXPOSE 8080
 CMD [ "node", "server-fake-site.js" ]

--- a/assets/comment-x-client.js
+++ b/assets/comment-x-client.js
@@ -762,8 +762,8 @@ const highlightedParliaProposalTemplate = (content) => {
     <div class="related-story-container">
       <div class="article-list article-list--related-story no-image">
         <div class="article-page__rich-text">
-          <div class="rich-text">       
-            <blockquote class="parlia-embed"><p lang="en" dir=”ltr”><a href="https://www.parlia.com/c/${content.commenter_comment}">Does the marketplace of ideas work?</a></p></blockquote><script async src="https://www.parlia.com/widgets/embed.js" charset="utf-8"></script>
+          <div class="rich-text">
+          <blockquote class="parlia-embed"><p lang="en" dir="ltr"><a href="${content.commenter_comment}">${content.commenter_comment}</a></p></blockquote> 
           </div>
         </div>
       </div>
@@ -789,12 +789,25 @@ async function getHighlightedComment() {
           let chosenComment = data.filter(comment => comment.author_id === authorCommentId)
           data = chosenComment[0]
           if (data.author_id === authorCommentId) {
-            let highlightedCommentBox = document.querySelector('#highlighted-comment')
-            if (data.commenter_comment.includes("PARLIA")) { 
-              highlightedCommentBox.innerHTML = highlightedParliaProposalTemplate(data)
-            } else {
+            let highlightedCommentBox = document.querySelector('#highlighted-comment');
+            try {
+              if (data.commenter_comment.includes("https://www.parlia.com/c/")) {
+                var parliaUrlFirst = data.commenter_comment.split('"')[1]
+                var parliaUrl = parliaUrlFirst.split('"')[0]
+                data.commenter_comment = parliaUrl;
+                highlightedCommentBox.innerHTML = highlightedParliaProposalTemplate(data)
+                var ref = document.getElementsByTagName('script')[0];
+                var script = document.createElement('script');
+                script.src = "{{parliaUrl}}";
+                ref.parentNode.insertBefore(script, ref);
+              } else {
+                throw ('Not Parlia')
+              }
+            } catch (e) {
               highlightedCommentBox.innerHTML = highlightedCommentTemplate(data)
             }
+
+
           }
         }
       }
@@ -894,7 +907,7 @@ async function startRevShare() {
     newMonetizationTag.name = 'monetization'
     newMonetizationTag.content = pickPointer()
     document.head.appendChild(newMonetizationTag)
-    
+
     if (window.initMonetizationAnalytics) {
       window.initMonetizationAnalytics()
       console.log('Monetization analytics event called.')

--- a/assets/comment-x-client.js
+++ b/assets/comment-x-client.js
@@ -754,6 +754,29 @@ const highlightedCommentTemplate = (content) => {
 }
 
 
+const highlightedParliaProposalTemplate = (content) => {
+  return `
+  <div class="related-story highlighted-comment" data-comment-id="${content.comment_id}">
+    <h3 class="related-story-suggestion">Highlighted comment, by <span class="highlighted-comment-author">${content.commenter_name}</span>
+    </h3>
+    <div class="related-story-container">
+      <div class="article-list article-list--related-story no-image">
+        <div class="article-page__rich-text">
+          <div class="rich-text">       
+            <blockquote class="parlia-embed"><p lang="en" dir=”ltr”><a href="https://www.parlia.com/c/${content.commenter_comment}">Does the marketplace of ideas work?</a></p></blockquote><script async src="https://www.parlia.com/widgets/embed.js" charset="utf-8"></script>
+          </div>
+        </div>
+      </div>
+      <div class="related-story-meta">
+        <p>This comment has been highlighted by the article's author and the commenter is enjoying a small percentage of this page's revenue. <a style="font-size: inherit; color: inherit;" class="article-list__title" href="/rewardcomments">Find out more</a></p>
+      </div>
+    </div>
+
+  </div>
+  `
+}
+
+
 
 async function getHighlightedComment() {
   if (authorCommentId) {
@@ -767,7 +790,11 @@ async function getHighlightedComment() {
           data = chosenComment[0]
           if (data.author_id === authorCommentId) {
             let highlightedCommentBox = document.querySelector('#highlighted-comment')
-            highlightedCommentBox.innerHTML = highlightedCommentTemplate(data)
+            if (data.commenter_comment.includes("PARLIA")) { 
+              highlightedCommentBox.innerHTML = highlightedParliaProposalTemplate(data)
+            } else {
+              highlightedCommentBox.innerHTML = highlightedCommentTemplate(data)
+            }
           }
         }
       }

--- a/assets/comment-x-client.js
+++ b/assets/comment-x-client.js
@@ -763,7 +763,10 @@ const highlightedParliaProposalTemplate = (content) => {
       <div class="article-list article-list--related-story no-image">
         <div class="article-page__rich-text">
           <div class="rich-text">
-          <blockquote class="parlia-embed"><p lang="en" dir="ltr"><a href="${content.commenter_comment}">${content.commenter_comment}</a></p></blockquote> 
+          <blockquote class="parlia-embed"><p lang="en" dir="ltr"><a href="${content.parliaUrl}">${content.parliaUrl}</a></p></blockquote> 
+          </div>
+          <div class="rich-text">       
+            ${content.commenter_comment}       
           </div>
         </div>
       </div>
@@ -794,7 +797,7 @@ async function getHighlightedComment() {
               if (data.commenter_comment.includes("https://www.parlia.com/c/")) {
                 var parliaUrlFirst = data.commenter_comment.split('"')[1]
                 var parliaUrl = parliaUrlFirst.split('"')[0]
-                data.commenter_comment = parliaUrl;
+                data.parliaUrl = parliaUrl;
                 highlightedCommentBox.innerHTML = highlightedParliaProposalTemplate(data)
                 var ref = document.getElementsByTagName('script')[0];
                 var script = document.createElement('script');

--- a/public/parlia-embed-local.js
+++ b/public/parlia-embed-local.js
@@ -1,0 +1,86 @@
+!(function (e) {
+    var t = {};
+    function r(n) {
+      if (t[n]) return t[n].exports;
+      var a = (t[n] = { i: n, l: !1, exports: {} });
+      return e[n].call(a.exports, a, a.exports, r), (a.l = !0), a.exports;
+    }
+    (r.m = e),
+      (r.c = t),
+      (r.d = function (e, t, n) {
+        r.o(e, t) || Object.defineProperty(e, t, { enumerable: !0, get: n });
+      }),
+      (r.r = function (e) {
+        "undefined" != typeof Symbol && Symbol.toStringTag && Object.defineProperty(e, Symbol.toStringTag, { value: "Module" }), Object.defineProperty(e, "__esModule", { value: !0 });
+      }),
+      (r.t = function (e, t) {
+        if ((1 & t && (e = r(e)), 8 & t)) return e;
+        if (4 & t && "object" == typeof e && e && e.__esModule) return e;
+        var n = Object.create(null);
+        if ((r.r(n), Object.defineProperty(n, "default", { enumerable: !0, value: e }), 2 & t && "string" != typeof e))
+          for (var a in e)
+            r.d(
+              n,
+              a,
+              function (t) {
+                return e[t];
+              }.bind(null, a)
+            );
+        return n;
+      }),
+      (r.n = function (e) {
+        var t =
+          e && e.__esModule
+            ? function () {
+                return e.default;
+              }
+            : function () {
+                return e;
+              };
+        return r.d(t, "a", t), t;
+      }),
+      (r.o = function (e, t) {
+        return Object.prototype.hasOwnProperty.call(e, t);
+      }),
+      (r.p = ""),
+      r((r.s = 0));
+  })([
+    function (e, t) {
+      function r() {
+        for (var e = Array.from(document.getElementsByClassName("parlia-embed")), t = 0; t < e.length; t++) {
+          var r = e[t],
+            i = r.getElementsByTagName("a");
+          if (1 != i.length) throw new Error("parlia-embed: expected to only find one link as child of parlia-embed");
+          var o = i[0].href,
+            l = n(o),
+            d = "";
+          true && (d = "display: inline-block;");
+          var c = a(
+            '<div class="parlia-embed-outer" style="width: 100%; max-width: 370px; margin: 10px 0; ' +
+              d +
+              '"><iframe class="parlia-embed-iframe" src="' +
+              l +
+              '" data-hj-allow-iframe style="height: 460px; width:100%; max-width: 370px; display: block;" frameborder="0" allowfullscreen scrolling="no" allowtransparency="true"></iframe><div class="parlia-embed-tagline" style="font-family: sans-serif; text-align: center; font-size: 16px;"><a href="' +
+              o +
+              '">Improving civil discourse</a> with <a href="https://www.parlia.com/">Parlia</a></div></div>'
+          );
+          r.replaceWith(c);
+        }
+      }
+      function n(e) {
+        var t = new URL(e);
+        if (!/[a-z0-9-\/]/.test(t.pathname)) throw new Error("parlia-embed: invalid path");
+        if (0 === t.pathname.lastIndexOf("/embed/", 0)) throw new Error("parlia-embed: URL must be article URL, not /embed/ URL");
+        return (t.pathname = "/embed" + t.pathname), t.href;
+      }
+      function a(e) {
+        var t = document.createElement("template");
+        t.innerHTML = e.trim();
+        var r = t.content.firstElementChild;
+        if (!r) throw new Error("parlia-embed: creating iframe element failed");
+        return r;
+      }
+      window.parliaEmbed || /(MSIE ([6789]|10|11))|Trident/.test(navigator.userAgent) || ((window.parliaEmbed = !0), /complete|interactive|loaded/.test(document.readyState) ? r() : document.addEventListener("DOMContentLoaded", r, !1));
+    },
+  ]);
+  

--- a/server-service.js
+++ b/server-service.js
@@ -54,6 +54,7 @@ app.get('/assets/client.js', function (req, res) {
         pageRootUrl: process.env.PAGE_ROOT_URL,
         coralRootUrl: process.env.CORAL_ROOT_URL,
         externalServiceRootUrl: process.env.SERVICE_ROOT_URL,
+        parliaUrl: process.env.PARLIA_EMBED_URL
     });
 })
 

--- a/views/article.html
+++ b/views/article.html
@@ -28,7 +28,7 @@
 
     <meta name="monetization" content="$ilp.uphold.com/Dgm4mYFp8HhA" />
 
-    <link rel="stylesheet" type="text/css" href="https://cdn-prod.opendemocracy.net/assets/css/screen.min.css?d41d8cd9">
+    <link rel="stylesheet" type="text/css" href="https://cdn-prod.opendemocracy.net/assets/css/screen.min.css?0f8a6407">
 
     <link rel="shortcut icon" href="https://cdn-prod.opendemocracy.net/assets/images/favicons/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180"
@@ -51,7 +51,23 @@
 
 
 
+
+
+
+
     <div class="global-wrapper" id="top">
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -351,6 +367,16 @@
 
 
                                         <li class="navigation__sub-menu-item ">
+                                            <a role="menuitem" tabindex="-1" href="/en/freedom-of-information/">
+                                                Freedom of Information
+                                            </a>
+                                        </li>
+
+
+
+
+
+                                        <li class="navigation__sub-menu-item ">
                                             <a role="menuitem" tabindex="-1" href="/en/global-extremes/">
                                                 Global Extremes
                                             </a>
@@ -443,26 +469,6 @@
                                         <li class="navigation__sub-menu-item ">
                                             <a role="menuitem" tabindex="-1" href="/en/rethinking-populism/">
                                                 Rethinking Populism
-                                            </a>
-                                        </li>
-
-
-
-
-
-                                        <li class="navigation__sub-menu-item ">
-                                            <a role="menuitem" tabindex="-1" href="/en/shine-a-light/">
-                                                Shine A Light
-                                            </a>
-                                        </li>
-
-
-
-
-
-                                        <li class="navigation__sub-menu-item ">
-                                            <a role="menuitem" tabindex="-1" href="/en/transformation/">
-                                                Transformation
                                             </a>
                                         </li>
 
@@ -637,7 +643,18 @@
                                                     </a>
                                                 </div>
                                             </li>
-
+                                            <li class="follow-od__list-item">
+                                                <div class="icon-container">
+                                                    <a tabindex="-1" href="https://twitter.com/opendemocracy"
+                                                        class="icon-twitter">
+                                                        <svg role="img" class="icon icon-twitter" viewBox="8 8 35 35"
+                                                            width="30px" height="30px" aria-hidden="true">
+                                                            <use xlink:href="#icon-twitter" class="icon-style"></use>
+                                                        </svg>
+                                                        <span class="invisible-content">openDemocracy Twitter</span>
+                                                    </a>
+                                                </div>
+                                            </li>
                                             <li class="follow-od__list-item">
                                                 <div class="icon-container">
                                                     <a tabindex="-1" href="http://bit.ly/odytsub" class="icon-youtube">
@@ -882,6 +899,16 @@
 
 
                                 <li class="navigation__sub-menu-item ">
+                                    <a role="menuitem" tabindex="-1" href="/en/freedom-of-information/">
+                                        Freedom of Information
+                                    </a>
+                                </li>
+
+
+
+
+
+                                <li class="navigation__sub-menu-item ">
                                     <a role="menuitem" tabindex="-1" href="/en/global-extremes/">
                                         Global Extremes
                                     </a>
@@ -974,26 +1001,6 @@
                                 <li class="navigation__sub-menu-item ">
                                     <a role="menuitem" tabindex="-1" href="/en/rethinking-populism/">
                                         Rethinking Populism
-                                    </a>
-                                </li>
-
-
-
-
-
-                                <li class="navigation__sub-menu-item ">
-                                    <a role="menuitem" tabindex="-1" href="/en/shine-a-light/">
-                                        Shine A Light
-                                    </a>
-                                </li>
-
-
-
-
-
-                                <li class="navigation__sub-menu-item ">
-                                    <a role="menuitem" tabindex="-1" href="/en/transformation/">
-                                        Transformation
                                     </a>
                                 </li>
 
@@ -1239,22 +1246,25 @@
         <main id="main-content">
 
 
-            <article class="article-page">
+            <article class="article-page ">
 
                 <div class="article-page__header article-page--header-extended">
                     <div class="article-page__wrapper">
 
                         <div class="article-page__project project project-digitaliberties ">
-                            <a href="/en/digitaliberties/">digitaLiberties:&nbsp;Opinion</a>
+                            <a href="/en/digitaliberties/">digitaLiberties:&nbsp;News</a>
 
                         </div>
 
 
-                        <h1 class="article-page__title">{{pageTitle}}</h1>
+                        <h1 class="article-page__title">Money systems are being rebuilt – who’s in control?</h1>
 
                         <div class="article-page__summary-container">
                             <div class="article-page__summary">
-                                <div class="rich-text"></div>
+                                <div class="rich-text">
+                                    <p>Organisations like openDemocracy and our reader community can participate in
+                                        shaping what monetary forms prevail</p>
+                                </div>
                             </div>
                         </div>
 
@@ -1285,7 +1295,7 @@
                         </div>
 
                         <div class="article-page__date">
-                            1 September 2020
+                            8 March 2021, 3.43pm
                         </div>
                     </div>
                 </div>
@@ -1310,15 +1320,15 @@
                     <div class="article-page__main-img-container">
                         <figure>
 
-                            <img alt="" srcset="https://cdn-prod.opendemocracy.net/media/images/pexels-andrea-piacquadio-3807747.max-1520x1008.jpg 2x,
-            https://cdn-prod.opendemocracy.net/media/images/pexels-andrea-piacquadio-3807747.max-760x504.jpg 1x"
-                                src="https://cdn-prod.opendemocracy.net/media/images/pexels-andrea-piacquadio-3807747.max-760x504.jpg"
-                                width="756" height="504" class="None">
+                            <img alt="" srcset="https://cdn-prod.opendemocracy.net/media/images/TXNY8F.max-1520x1008.jpg 2x,
+                  https://cdn-prod.opendemocracy.net/media/images/TXNY8F.max-760x504.jpg 1x"
+                                src="https://cdn-prod.opendemocracy.net/media/images/TXNY8F.max-760x504.jpg" width="756"
+                                height="504" class="None">
 
 
                             <figcaption>
-                                <div class="rich-text">Woman views content picked especially for her.</div> | <div
-                                    class="rich-text">Photo by Andrea Piacquadio from Pexels</div>
+                                <div class="rich-text">We can design systems that improve how people behave and are
+                                    rewarded online</div> | <div class="rich-text">Chris Rout / Alamy Stock Photo</div>
                             </figcaption>
                         </figure>
 
@@ -1327,10 +1337,291 @@
 
 
 
+                </div>
 
-
+                <div class="article-page__sidebars-and-richtext">
                     <div class="article-page__left-sidebar">
 
+                        <div class="sidebar sidebar--share-article">
+
+                            <h1 class="sidebar__heading">Share this</h1>
+
+                            <ul class="sidebar__share-options-list">
+                                <li>
+                                    <div class="icon-container">
+                                        <a href="https://twitter.com/intent/tweet?text=Money systems are being rebuilt – who’s in control?&url=https%3A//www.opendemocracy.net/en/digitaliberties/money-systems-are-being-rebuilt-whos-in-control/?utm_source=tw&utm_medium=ar"
+                                            aria-haspopup="false">
+                                            <svg role="img" class="icon icon-twitter" viewBox="0 0 50 50" width="50px"
+                                                height="50px">
+                                                <title>Share on Twitter</title>
+                                                <use xlink:href="#icon-twitter" class="icon-style"></use>
+                                            </svg>
+                                        </a>
+                                    </div>
+                                </li>
+
+                                <li>
+                                    <div class="icon-container">
+                                        <a href="https://www.facebook.com/sharer.php?u=https%3A//www.opendemocracy.net/en/digitaliberties/money-systems-are-being-rebuilt-whos-in-control/?utm_source=fb&utm_medium=ar"
+                                            data-service="facebook" aria-haspopup="false">
+                                            <svg role="img" class="icon icon-facebook" viewBox="0 0 50 50" width="50px"
+                                                height="50px">
+                                                <title>Share on Facebook</title>
+                                                <use xlink:href="#icon-facebook"></use>
+                                            </svg>
+                                        </a>
+                                    </div>
+                                </li>
+
+                                <li>
+                                    <div class="icon-container">
+                                        <a href="https://wa.me/?text=https%3A//www.opendemocracy.net/en/digitaliberties/money-systems-are-being-rebuilt-whos-in-control/?utm_source=wa&utm_medium=ar"
+                                            data-service="whatsapp" aria-haspopup="false">
+                                            <svg role="img" class="icon icon-whatsapp" viewBox="-8 -8 50 50"" width="
+                                                50px" height="50px">
+                                                <title>Share on WhatsApp</title>
+                                                <use xlink:href="#icon-whatsapp"></use>
+                                            </svg>
+                                        </a>
+                                    </div>
+                                </li>
+
+                                <li>
+                                    <div class="icon-container">
+                                        <a href="/cdn-cgi/l/email-protection#c2fde4b1b7a0a8a7a1b6ff8fadaca7bbe7f0f2b1bbb1b6a7afb1e7f0f2a3b0a7e7f0f2a0a7abaca5e7f0f2b0a7a0b7abaeb6e7f0f2e787f0e7faf2e7fbf1e7f0f2b5aaade787f0e7faf2e7fbfbb1e7f0f2abace7f0f2a1adacb6b0adaee7f184e4a0ada6bbffaab6b6b2b1e7f183ededb5b5b5ecadb2a7aca6a7afada1b0a3a1bbecaca7b6eda7aceda6aba5abb6a3aeaba0a7b0b6aba7b1edafadaca7bbefb1bbb1b6a7afb1efa3b0a7efa0a7abaca5efb0a7a0b7abaeb6efb5aaadb1efabacefa1adacb6b0adaeedfdb7b6af9db1adb7b0a1a7ffa7afe4b7b6af9dafa7a6abb7afffa3b0"
+                                            aria-haspopup="false">
+                                            <svg role="img" class="icon icon-email" viewBox="0 0 50 50" width="50px"
+                                                height="50px">
+                                                <title>Share via email</title>
+                                                <use xlink:href="#icon-email"></use>
+                                            </svg>
+                                        </a>
+                                    </div>
+                                </li>
+
+                                <li>
+                                    <div class="icon-container">
+                                        <a href="#" class="share-link" aria-haspopup="false">
+                                            <svg role="img" class="icon icon-link" viewBox="0 0 50 50" width="50px"
+                                                height="50px">
+                                                <title>Share link</title>
+                                                <use xlink:href="#icon-link"></use>
+                                            </svg>
+                                        </a>
+                                    </div>
+                                </li>
+                            </ul>
+                            <span class="confirmation-text">URL copied to clipboard</span>
+                        </div>
+
+                    </div>
+
+                    <div class="article-page__middle-column">
+
+
+
+                        <div class="article-page__bullet_points">
+                            <ul class="bullet-point-container">
+
+                                <li class="article_bullet_point">
+                                    <p>New monetary technologies are emerging which could enable better incentives on
+                                        the internet</p>
+                                </li>
+
+                                <li class="article_bullet_point">
+                                    <p>With care, we can design systems that improve how information is created, and how
+                                        people behave and are rewarded online</p>
+                                </li>
+
+                                <li class="article_bullet_point">
+                                    <p>openDemocracy’s comments experiment, supported by <a
+                                            href="https://www.grantfortheweb.org/">grantfortheweb.org</a>, is an example
+                                        of how micropayments can be used to this end</p>
+                                </li>
+
+                            </ul>
+                        </div>
+                        <div class="article-page__rich-text">
+
+                            <div class="rich-text">
+                                <p>The internet started out as a richly utopian prospect. Free and fast information for
+                                    all would flush out falsehood and produce optimally informed citizens, so they said.
+                                    It would be a lot of fun too!</p>
+                                <p>That dream has long since soured and the world seems to be engulfed by gales of
+                                    deviant data.</p>
+                                <p>In response we call tirelessly for regulation and plead for virtuous behaviour from
+                                    corporations who are constitutionally incapable of detoxifying their products. The
+                                    incentives are wrong: earnings are fattest when <a
+                                        href="https://www.youtube.com/watch?v=uaaC57tcci0">they leverage human
+                                        psychology to drive dependency and inflamed emotion</a> on their platforms.</p>
+                                <p>We, as citizens and civil society, should seek to tackle this by designing new ways
+                                    of engaging online.</p>
+                                <h2>Engineering incentives</h2>
+                                <p>The web is often described as a key site of the “attention economy” where limits on
+                                    people&#x27;s capacity to engage are stretched and fought over by competing sites,
+                                    apps, and products.</p>
+                                <p>There are many aspects to consider about how people behave online: where they choose
+                                    to spend their time; why they decide to engage with certain elements on a page;
+                                    whether they remain civil, comment constructively, express encouragement with a like
+                                    button, or choose to play moderator by reporting problematic submissions.</p>
+                                <p>Whatever motivates people’s actions online is worth understanding. At best, we can
+                                    use this understanding to help us design experiences that achieve different results.
+                                    By considering what incentives are part of a given web experience and finding ways
+                                    to alter or augment those we might cultivate preferable online spaces.</p>
+                                <p>This should be done with humility – the techno-solutionist attitude that we can
+                                    neatly solve society’s ills with code, when applied thoughtlessly or with hubris,
+                                    often makes things worse.</p>
+                                <p>However, since we do use technology to conduct our affairs, it’s essential that we
+                                    question and take part in its design.</p>
+                                <h2>Digital money is a paradigm, shifting around us</h2>
+                                <p>We are currently seeing a raft of developments that aim to reconstruct financial
+                                    life. Whilst <a
+                                        href="https://www.opendemocracy.net/en/opendemocracyuk/war-on-cash/">the war on
+                                        cash advances steadily</a>, new monetary forms are burbling across the internet
+                                    poised to bring transformation.</p>
+                                <p>The realm of cryptocurrency, a frenzied hotbed of hype and hyper-valuation, is slowly
+                                    settling into a mature landscape of new-fangled finance platforms and visionary
+                                    governance systems undergirded by programmable money.</p>
+                                <p>Data-first policies, such as the UK’s <a href="https://www.openbanking.org.uk/">Open
+                                        Banking</a>, are unleashing swathes of disruptive finance.</p>
+                                <p>China is setting new precedents for how money is managed, from WeChat’s omnipresent
+                                    payments to the Central Bank’s march toward digital currency.</p>
+                            </div>
+                        </div>
+                        <div class="article-page__media-content">
+
+
+
+
+
+
+
+
+
+
+
+
+                            <figure>
+
+
+
+
+                                <img alt="WeChat and AliPay stickers next to Visa and Mastercard on a bakery window illustrate the changing payments landscape."
+                                    srcset="https://cdn-prod.opendemocracy.net/media/images/HK_Wan_Zi__Wan_Chai_Huang_Hou_Da_Dao_Dong__Qu.width-1600.jpg 2x,
+                  https://cdn-prod.opendemocracy.net/media/images/HK_Wan_Zi__Wan_Chai_Huang_Hou_Da_Dao_Dong__Que.width-800.jpg 1x"
+                                    src="https://cdn-prod.opendemocracy.net/media/images/HK_Wan_Zi__Wan_Chai_Huang_Hou_Da_Dao_Dong__Que.width-800.jpg"
+                                    width="800" height="516" class="full">
+
+
+
+                                <figcaption>
+                                    WeChat and AliPay stickers next to Visa and Mastercard on a bakery window illustrate
+                                    the changing payments landscape. | Photo: DECKLONGBOO/Wikimedia Commons, CC-BY-SA
+                                    4.0
+                                </figcaption>
+
+                            </figure>
+                        </div>
+                        <div class="article-page__rich-text">
+
+                            <div class="rich-text">
+                                <p>Those currency plans arrived at a time when cryptocurrencies had proved they could
+                                    hold and transfer value without state sanction or control. Facebook tried to launch
+                                    its own version in the brazen hope of cornering global payments whilst knowing the
+                                    US government <a
+                                        href="https://www.wired.co.uk/article/facebook-internet-force-for-good">would
+                                        prefer a homegrown corporation in control of money</a>.</p>
+                                <p>These fundamental shifts in how money works will redefine how it shapes political
+                                    reality. The various technologies involved offer different visions of what we think
+                                    of as money in future, who controls it, the role of the state, and how it allows us
+                                    to craft our lives and economies.</p>
+                                <p><a
+                                        href="https://www.ft.com/content/abb8ebe1-99e1-4547-8c42-df265bf5125c?shareType=nongift">Given
+                                        wider trends</a> in which <a
+                                        href="https://www.politico.com/news/2020/11/20/twitter-trump-transition-biden-potus-438880">tech
+                                        firms set regulation</a>, it’s possible that no government will have the
+                                    technical prowess to decide what money system presides in future. We, as citizens,
+                                    must become active in designing and deciding that.</p>
+                                <p>We have still not seen a victor in this realm, yet whatever systems do triumph will
+                                    smuggle their own ideologies with them.</p>
+                                <h2>Aspirations for the world’s new monies</h2>
+                                <p>These trends prompt us to think about what we might hope for from monetary systems.
+                                </p>
+                                <p>Cryptocurrencies have promised radically transparent, open-source forms of money. A
+                                    heady melange of libertarian and global-democratic values, the blockchain scene that
+                                    they spring from proposes a whole host of alternatives. They extol decentralization
+                                    as a core principle, undoing the need for governments to provide the mechanics of
+                                    money.</p>
+                                <p>Related systems that propose to give us new ways of doing money include <a
+                                        href="https://hackernoon.com/last-night-a-distributed-cooperative-organization-saved-my-life-a-brief-introduction-to-discos-4u5cv2zmn">Digital
+                                        Autonomous Organisations</a> , <a
+                                        href="https://joincircles.net/#about">Universal Basic Income</a>, <a
+                                        href="https://www.ft.com/content/cf875d9a-5be6-11e5-a28b-50226830d644">local
+                                        currency systems</a>, and new web-native protocols like <a
+                                        href="https://interledger.org/">Interledger</a> for peer-to-peer cross-border
+                                    payments.</p>
+                                <p>What seems certain is that money will look different in the future than it does
+                                    today, and a great number of folk are vying to define the rules.</p>
+                                <h2>Experimenting with payments to support comments</h2>
+                                <p>Against this backdrop, organisations like openDemocracy and our reader community can
+                                    participate in shaping what monetary forms prevail.</p>
+                                <p>Our current experiment with micropayments for comments is an example.</p>
+                                <p>Comment spaces are a melting pot of useful corrections, spirited disagreements,
+                                    fast-moving collaborations and calamitous toxicity. A lot has been said about what
+                                    they do for our communities. We wouldn’t want to remove the ability for readers to
+                                    participate in articles but nor can we tolerate the worst excesses of online debate.
+                                </p>
+                                <p>By employing new incentives in this way we hope to tap into latent resources to
+                                    nurture the debates that accompany our articles.</p>
+                                <p>The feature we have introduced is just one variety of monetised comment. There are a
+                                    multitude of ways to re-align incentives using financial and other mechanisms. This
+                                    is just one attempt.</p>
+                                <p><b>» Comment on this article (below) to use this feature.</b></p>
+                                <h2>How should we design a market of comments?</h2>
+                                <p>By introducing financial incentives into the publishing flow we open up a host of
+                                    possibilities, as well as possible problems. Even prior to adding them a number of
+                                    incentives and disincentives already exist that affect a reader’s disposition to
+                                    engage.</p>
+                                <p>Many comment spaces are organically lively, bristling with impassioned participants
+                                    who partake because they want to be heard, they believe in the public square, and
+                                    they want to bring their knowledge to the debate. Could it be poisonous to introduce
+                                    financial rewards and incentives to such spaces of civic purity?</p>
+                                <p>It’s widely agreed that journalists should be paid for their efforts in writing
+                                    articles. Whilst this does not always happen, financial recognition for those who
+                                    toil to improve our discourse with good writing is something to strive for. With
+                                    this experiment, we may extend that to comment writers, potentially expanding the
+                                    economy of good writing and rewarding research which currently goes without
+                                    remuneration.</p>
+                                <p>Nevertheless, experimenting with novel incentive schemes must be done with care and a
+                                    view to avoiding unsavoury outcomes.</p>
+                                <p>With all of this in mind, we invite our readers and commenters to take part, to get a
+                                    feel for the new systems we are using, and make your views heard. This is a live
+                                    experiment and your thoughts can contribute to the designs that come next.</p>
+                                <p>Add your comment below – if it gets promoted, you could get a share of revenue to
+                                    this page.</p>
+                            </div>
+                        </div>
+                        <div class="article-page__rich-text">
+
+                            <div class="rich-text">
+                                <p></p>
+                                <hr />
+                                <h4>How will comments be rewarded?</h4>
+                                <p>Our new feature, supported with a <a
+                                        href="http://grantfortheweb.org/">grantfortheweb.org</a>, gives payment options
+                                    that let readers reward authors and commenters. By setting up <a
+                                        href="http://coil.com/">Coil</a> micropayments you can support authors on our
+                                    site, and also the authors of comments that have been highlighted by an article’s
+                                    author. <a href="http://opendemocracy.net/paycommentauthors">Read more about how it
+                                        works or comment below to see it in action</a> .</p>
+                            </div>
+                        </div>
+
+
+
+
+
+                        <div id="highlighted-comment"></div>
 
                     </div>
 
@@ -1360,101 +1651,6 @@
                             </div>
                         </div>
                     </div>
-
-
-
-
-                    <div class="article-page__rich-text">
-
-                        <div class="rich-text">
-                            <p>Data is at work in every part of your life.</p>
-                            <p>Retailers, governments, employers and more see it as a critical part of knowing how you
-                                tick and controlling interactions with you.</p>
-                            <p>For better and worse it’s happening everywhere so we better get wise to how it actually
-                                happens.</p>
-                            <p>yourData is openDemocracy’s project to promote data transparency. We explore ways to show
-                                people how their data is used by data-driven websites. If a website shows me an article,
-                                or tries to sell me a product, or manages my access to government services, I want to
-                                know if and how they’re using my data (like my current location, my gender, or my race)
-                                to make that decision. That decision is called personalisation and it’s a filter that
-                                you typically have little knowledge of or control over.</p>
-                        </div>
-                    </div>
-
-
-
-                    <div class="related-story">
-                        <h3 class="related-story-suggestion">Related story</h3>
-
-                        <div class="related-story-container">
-
-                            <div class="related-story-image-container">
-                                <a class="article-list__title"
-                                    href="/en/digitaliberties/your-data-makes-web-personal/?source=in-article-related-story">
-                                    <img alt="Photo by Christina Morillo from Pexels - woman-standing-while-carrying-laptop-1181354.jpg"
-                                        class="article-list__img related-story-image" height="226"
-                                        src="https://cdn-prod.opendemocracy.net/media/images/Photo_by_Christina_Morillo_from_Pexels_-_wom.max-340x340.jpg"
-                                        width="340">
-                                </a>
-                            </div>
-
-
-
-
-                            <div class="article-list article-list--related-story with-image">
-                                <div><a class="article-list__title"
-                                        href="/en/digitaliberties/your-data-makes-web-personal/?source=in-article-related-story">Your
-                                        data makes the web personal</a></div>
-                                <div class="related-story-meta">
-                                    21-10-2020 |
-
-                                    Matthew Linares
-
-
-                                </div>
-                                <div>Online personalisation is where you see specific content based on your personal
-                                    data. How bad can it be?</div>
-                            </div>
-                        </div>
-                    </div>
-
-
-
-
-                    <div class="article-page__highlight">
-                        <blockquote class="blockquote__pull-quote-quotation">
-                            <div class="blockquote__container">
-                                <div class="rich-text">
-                                    <p>We tend to be less comfortable when we find out the business knows where in a
-                                        building we live, what time we leave the house and who we’ve slept alongside...
-                                    </p>
-                                </div>
-                            </div>
-
-                        </blockquote>
-                    </div>
-
-
-
-
-
-
-
-                    <div class="article-page__rich-text">
-
-                        <div class="rich-text">
-                            <p></p>
-                            <p>3) interview digital activists of various distinctions. Policy lobbyists, support groups
-                                for vulnerable people, law firms, and organizations that encourage citizens to reclaim
-                                their digital rights. There are many out there and openDemocracy can highlight their
-                                challenges!</p>
-                            <p></p>
-
-
-
-                        </div>
-                    </div>
-                    <div id="highlighted-comment"></div>
                 </div>
             </article>
 
@@ -1473,7 +1669,7 @@
                     <ul class="sidebar__share-options-list">
                         <li>
                             <div class="icon-container">
-                                <a href="https://twitter.com/intent/tweet?text={{pageTitle}}&url=https%3A//www.opendemocracy.net/en/digitaliberties/designing-data-transparency-ideas-from-the-community/?utm_source=tw&utm_medium=ar"
+                                <a href="https://twitter.com/intent/tweet?text=Money systems are being rebuilt – who’s in control?&url=https%3A//www.opendemocracy.net/en/digitaliberties/money-systems-are-being-rebuilt-whos-in-control/?utm_source=tw&utm_medium=ar"
                                     aria-haspopup="false">
                                     <svg role="img" class="icon icon-twitter" viewBox="0 0 50 50" width="50px"
                                         height="50px">
@@ -1486,7 +1682,7 @@
 
                         <li>
                             <div class="icon-container">
-                                <a href="https://www.facebook.com/sharer.php?u=https%3A//www.opendemocracy.net/en/digitaliberties/designing-data-transparency-ideas-from-the-community/?utm_source=fb&utm_medium=ar"
+                                <a href="https://www.facebook.com/sharer.php?u=https%3A//www.opendemocracy.net/en/digitaliberties/money-systems-are-being-rebuilt-whos-in-control/?utm_source=fb&utm_medium=ar"
                                     data-service="facebook" aria-haspopup="false">
                                     <svg role="img" class="icon icon-facebook" viewBox="0 0 50 50" width="50px"
                                         height="50px">
@@ -1499,7 +1695,7 @@
 
                         <li>
                             <div class="icon-container">
-                                <a href="https://wa.me/?text=https%3A//www.opendemocracy.net/en/digitaliberties/designing-data-transparency-ideas-from-the-community/?utm_source=wa&utm_medium=ar"
+                                <a href="https://wa.me/?text=https%3A//www.opendemocracy.net/en/digitaliberties/money-systems-are-being-rebuilt-whos-in-control/?utm_source=wa&utm_medium=ar"
                                     data-service="whatsapp" aria-haspopup="false">
                                     <svg role="img" class="icon icon-whatsapp" viewBox="-8 -8 50 50"" width=" 50px"
                                         height="50px">
@@ -1512,7 +1708,7 @@
 
                         <li>
                             <div class="icon-container">
-                                <a href="https://www.opendemocracy.net/cdn-cgi/l/email-protection#08372e7b7d6a626d6b7c354c6d7b616f6661666f2d3a386c697c692d3a387c7a69667b78697a6d666b712d3a382d4d3a2d30382d313b2d3a38616c6d697b2d3a386e7a67652d3a387c606d2d3a386b6765657d66617c712e6a676c7135607c7c787b2d3b4927277f7f7f2667786d666c6d65676b7a696b7126666d7c276d66276c616f617c6964616a6d7a7c616d7b276c6d7b616f6661666f256c697c69257c7a69667b78697a6d666b7125616c6d697b256e7a6765257c606d256b6765657d66617c7127377d7c65577b677d7a6b6d356d652e7d7c6557656d6c617d6535697a"
+                                <a href="/cdn-cgi/l/email-protection#4d726b3e382f27282e39700022232834687f7d3e343e3928203e687f7d2c3f28687f7d2f2824232a687f7d3f282f38242139687f7d68087f68757d68747e687f7d3a252268087f68757d6874743e687f7d2423687f7d2e2223393f2221687e0b6b2f222934702539393d3e687e0c62623a3a3a63223d2823292820222e3f2c2e34632328396228236229242a24392c21242f283f3924283e622022232834603e343e3928203e602c3f28602f2824232a603f282f38242139603a25223e602423602e2223393f22216272383920123e22383f2e287028206b38392012202829243820702c3f"
                                     aria-haspopup="false">
                                     <svg role="img" class="icon icon-email" viewBox="0 0 50 50" width="50px"
                                         height="50px">
@@ -1541,265 +1737,6 @@
 
 
 
-            <section class="read-more">
-                <div class="section">
-
-                    <h3>Read more</h3>
-                    <ul class="article-list article-list--small-portrait">
-
-
-
-
-                        <li class="article-list__list-item">
-                            <div class="article-list__container">
-                                <div class="article-list__img-container">
-                                    <a class="article-list__img-link"
-                                        href="/en/digitaliberties/civil-society-collaborates-fix-tech/">
-
-
-                                        <a class="article-list__img-link"
-                                            href="/en/digitaliberties/civil-society-collaborates-fix-tech/">
-                                            <img alt="pexels-fauxels-3183197.jpg" class="article-list__img" height="165"
-                                                src="https://cdn-prod.opendemocracy.net/media/images/pexels-fauxels-3183197.2e16d0ba.fill-278x165.jpg"
-                                                width="278">
-                                        </a>
-
-                                    </a>
-                                </div>
-                                <div class="article-list__text">
-
-                                    <div class="project article-list__project project-digitaliberties">
-                                        <span class="invisible-content">Published in:</span>
-                                        <a href="/en/digitaliberties/">digitaLiberties</a>
-                                    </div>
-
-                                    <a class="article-list__title"
-                                        href="/en/digitaliberties/civil-society-collaborates-fix-tech/">
-                                        Civil society collaborates to fix tech
-                                    </a>
-                                    <div class="article-list__meta">
-
-
-
-                                        <div class="article-list__author">
-                                            <span class="invisible-content">Written by: Matthew Linares</span>
-                                            <a href="/en/author/matthew-linares/">
-                                                <span class="invisible-content">All articles by: </span>Matthew Linares
-                                            </a>
-                                        </div>
-
-
-
-                                    </div>
-                                </div>
-                            </div>
-                        </li>
-
-
-
-
-
-                        <li class="article-list__list-item">
-                            <div class="article-list__container">
-                                <div class="article-list__img-container">
-                                    <a class="article-list__img-link"
-                                        href="/en/can-europe-make-it/latest-personal-data-grab-eu-global-leader-personal-data-protection/">
-
-
-                                        <a class="article-list__img-link"
-                                            href="/en/can-europe-make-it/latest-personal-data-grab-eu-global-leader-personal-data-protection/">
-                                            <img alt="PA-54775252.jpg" class="article-list__img" height="165"
-                                                src="https://cdn-prod.opendemocracy.net/media/images/PA-54775252.2e16d0ba.fill-278x165.jpg"
-                                                width="278">
-                                        </a>
-
-                                    </a>
-                                </div>
-                                <div class="article-list__text">
-
-                                    <div class="project article-list__project project-can-europe-make-it">
-                                        <span class="invisible-content">Published in:</span>
-                                        <a href="/en/can-europe-make-it/">Can Europe Make It?</a>
-                                    </div>
-
-                                    <a class="article-list__title"
-                                        href="/en/can-europe-make-it/latest-personal-data-grab-eu-global-leader-personal-data-protection/">
-                                        The latest personal data grab: is the EU a global leader in personal data
-                                        protection?
-                                    </a>
-                                    <div class="article-list__meta">
-
-
-
-                                        <div class="article-list__author">
-                                            <span class="invisible-content">Written by: Elspeth Guild</span>
-                                            <a href="/en/author/elspeth-guild/">
-                                                <span class="invisible-content">All articles by: </span>Elspeth Guild
-                                            </a>
-                                        </div>
-
-                                        <div class="article-list__author">
-                                            <span class="invisible-content">Written by: Niovi Vavoula</span>
-                                            <a href="/en/author/niovi-vavoula-2/">
-                                                <span class="invisible-content">All articles by: </span>Niovi Vavoula
-                                            </a>
-                                        </div>
-
-
-
-                                    </div>
-                                </div>
-                            </div>
-                        </li>
-
-
-
-
-
-                        <li class="article-list__list-item">
-                            <div class="article-list__container">
-                                <div class="article-list__img-container">
-                                    <a class="article-list__img-link"
-                                        href="/en/digitaliberties/designing-data-transparency-ideas-from-the-community/">
-
-
-                                        <a class="article-list__img-link"
-                                            href="/en/digitaliberties/designing-data-transparency-ideas-from-the-community/">
-                                            <img alt="pexels-andrea-piacquadio-3807747.jpg" class="article-list__img"
-                                                height="165"
-                                                src="https://cdn-prod.opendemocracy.net/media/images/pexels-andrea-piacquadio-3807747.2e16d0ba.fill-278x165.jpg"
-                                                width="278">
-                                        </a>
-
-                                    </a>
-                                </div>
-                                <div class="article-list__text">
-
-                                    <div class="project article-list__project project-digitaliberties">
-                                        <span class="invisible-content">Published in:</span>
-                                        <a href="/en/digitaliberties/">digitaLiberties</a>
-                                    </div>
-
-                                    <a class="article-list__title"
-                                        href="/en/digitaliberties/designing-data-transparency-ideas-from-the-community/">
-                                        {{pageTitle}}
-                                    </a>
-                                    <div class="article-list__meta">
-
-
-
-                                        <div class="article-list__author">
-                                            <span class="invisible-content">Written by: Matthew Linares</span>
-                                            <a href="/en/author/matthew-linares/">
-                                                <span class="invisible-content">All articles by: </span>Matthew Linares
-                                            </a>
-                                        </div>
-
-
-
-                                    </div>
-                                </div>
-                            </div>
-                        </li>
-
-
-
-
-
-                        <li class="article-list__list-item">
-                            <div class="article-list__container">
-                                <div class="article-list__img-container">
-                                    <a class="article-list__img-link"
-                                        href="/en/oureconomy/can-europe-become-key-player-code-wars/">
-
-
-                                        <a class="article-list__img-link"
-                                            href="/en/oureconomy/can-europe-become-key-player-code-wars/">
-                                            <img alt="PA-50427412.jpg" class="article-list__img" height="165"
-                                                src="https://cdn-prod.opendemocracy.net/media/images/PA-50427412.2e16d0ba.fill-278x165.jpg"
-                                                width="278">
-                                        </a>
-
-                                    </a>
-                                </div>
-                                <div class="article-list__text">
-
-                                    <div class="project article-list__project project-oureconomy">
-                                        <span class="invisible-content">Published in:</span>
-                                        <a href="/en/oureconomy/">ourEconomy</a>
-                                    </div>
-
-                                    <a class="article-list__title"
-                                        href="/en/oureconomy/can-europe-become-key-player-code-wars/">
-                                        Can Europe become a key player in the code war?
-                                    </a>
-                                    <div class="article-list__meta">
-
-
-
-                                        <div class="article-list__author">
-                                            <span class="invisible-content">Written by: Rosie Collington</span>
-                                            <a href="/en/author/rosie-collington/">
-                                                <span class="invisible-content">All articles by: </span>Rosie Collington
-                                            </a>
-                                        </div>
-
-
-
-                                    </div>
-                                </div>
-                            </div>
-                        </li>
-
-
-                    </ul>
-
-                    <div class="read-more__all">
-
-
-
-                        <a href="/en/digitaliberties/">View all in digitaLiberties</a>
-
-
-                    </div>
-                </div>
-            </section>
-
-
-            <section id="newsletter" class="mailing-list mailing-list--wide mailing-list--primary">
-                <div class="mailing-list__container">
-
-                    <div class="mailing-list__text-container">
-                        <span class="mailing-list__title">Had enough of ‘alternative facts’?</span>
-                        <span class="mailing-list__sub-title">openDemocracy is different</span>
-                        <span class="mailing-list__text">Join the conversation: get our weekly email</span>
-                    </div>
-
-                    <div class="mailing-list__form-container">
-                        <form method="post" class="mailing-list__form" id="newsletter-signup-banner"
-                            action="/api/newsetter-subscribe/">
-
-                            <input type="hidden" name="csrfmiddlewaretoken"
-                                value="4vh07iFuTLHcJpWXpCEUw13FqzRPA55XNm0KEKfVXnsFW0Ir23MGLu5v2tffzVB9">
-
-                            <input type="hidden" name="list_id" value="17" id="newsletter-list_id">
-                            <div class="single textinput">
-                                <label for="newsletter-email-banner" class="is-required mailing-list__label">Enter your
-                                    email address</label>
-                                <input type="email" placeholder="Email address" name="newsletter-email-banner"
-                                    id="newsletter-email-banner" />
-                                <input type="text" placeholder="First name (optional)"
-                                    name="newsletter-first-name-banner" id="newsletter-first-name-banner" />
-                                <input type="text" placeholder="Last name (optional)" name="newsletter-last-name-banner"
-                                    id="newsletter-last-name-banner" />
-                            </div>
-                            <div class="buttons">
-                                <button type="submit" class="btn"><span>→</span></button>
-                            </div>
-                        </form>
-                    </div>
-                </div>
-            </section>
 
 
 


### PR DESCRIPTION
Hi @mattlinares I have added the Parlia embed URL (https://www.parlia.com/widgets/embed.js) as an environment variable on the server. If you want to test this locally, be sure to update your .env file with `PARLIA_EMBED_URL=http://localhost:4000/parlia-embed-local.js` (see `.env.default` below). 

Do we want the commenter to be able to write their own thoughts into the comment box as well? My commit "Allow comment alongside Parlia URL" implements this. So a commenter can write anything they like and it will pull out the Parlia embed URL and embed it, and display the full comment (including the URL again) after the embed.

I have tested thoroughly locally and am happy to deploy if you want to get this over to the Parlia team for testing today.